### PR TITLE
修正：都道府県絞り込み検索のデフォルトの値をnullに変更

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -8,7 +8,7 @@
                 @csrf
                 <div class="col-auto">
                     <select name="pref" id="pref" class="form-select" aria-label="都道府県">
-                        <option>都道府県を絞る</option>
+                        <option value="">都道府県を絞る</option>
                         @foreach ($prefectures as $prefecture)
                             <option 
                             value="{{ $prefecture->prefecture }}"


### PR DESCRIPTION
都道府県絞り込み検索機能のデフォルト値「都道府県を絞り込む」のvalueを「(null)」に変更しました。

